### PR TITLE
Fossil at the end of the VC backends list.

### DIFF
--- a/doc/index.wiki
+++ b/doc/index.wiki
@@ -23,13 +23,13 @@ buffer and do
 <code>C-x C-e</code> to execute it.
 
 <pre>
-(add-to-list 'vc-handled-backends 'Fossil)
+(add-to-list 'vc-handled-backends 'Fossil t)
 (load-file "/path/to/this/project/vc/el/vc-fossil.el")
 </pre>
 or if you would rather load the file lazily, compile the file (see
 below) and use this instead.
 <pre>
-(add-to-list 'vc-handled-backends 'Fossil)
+(add-to-list 'vc-handled-backends 'Fossil t)
 (autoload 'vc-fossil-registered "/path/to/this/project/vc/el/vc-fossil.elc")
 </pre>
 

--- a/vc/el/vc-fossil.el
+++ b/vc/el/vc-fossil.el
@@ -31,7 +31,7 @@
 ;; 2. Tell Emacs to load it when needed:
 ;;    (autoload 'vc-fossil-registered "vc-fossil")
 ;; 3. Add Fossil to the list of supported backends:
-;;    (add-to-list 'vc-handled-backends 'Fossil)
+;;    (add-to-list 'vc-handled-backends 'Fossil t)
 
 ;;; Implemented Functions
 ;; BACKEND PROPERTIES


### PR DESCRIPTION
This is in conformance with the practice for other VCs, which put
heavier-weight and more modern systems later on the list.
This can be seen in the default value of vc-handled-backends,
(RCS CVS SVN SCCS SRC Bzr Git Hg Mtn)